### PR TITLE
Change order of mp4 and webm in video sources

### DIFF
--- a/packages/textural-video/src/index.tsx
+++ b/packages/textural-video/src/index.tsx
@@ -78,10 +78,10 @@ const TexturalVideo = ({
             playsInline
             {...rest}
         >
+            {webm && <source src={webm} type="video/webm" />}
             {mp4 && (
                 <source src={mp4} type={isTransparent ? 'video/mp4; codecs="hvc1"' : 'video/mp4'} />
             )}
-            {webm && <source src={webm} type="video/webm" />}
         </video>
     );
 };


### PR DESCRIPTION
👋 noticed this recently on TCOM, it seems source order in the video element matters + we are prioritizing `mp4` over `webm`...proposing to swap the order to give priority to `webm`.

current:

<img width="1461" alt="Screenshot 2023-06-15 at 2 56 19 PM" src="https://github.com/MadeInHaus/haus-core/assets/6518748/2fd3a9b0-4277-42b9-8b03-79b3d4da21ac">

---

updated:

<img width="1461" alt="Screenshot 2023-06-15 at 2 56 48 PM" src="https://github.com/MadeInHaus/haus-core/assets/6518748/0fbec187-6f6e-4262-858e-4c069ccd4916">