### PR TITLE
Use primaryVideo and secondaryVideo props instead of mp4 and webm

### DIFF
--- a/.changeset/old-ducks-arrive.md
+++ b/.changeset/old-ducks-arrive.md
@@ -1,0 +1,5 @@
+---
+"@madeinhaus/textural-video": minor
+---
+
+Deprecate mp4 and webm props in favor of primaryVideoUrl and secondaryVideoUrl

--- a/packages/textural-video/src/index.tsx
+++ b/packages/textural-video/src/index.tsx
@@ -4,8 +4,18 @@ import { useIntersectionObserver } from '../../hooks/src/useIntersectionObserver
 export interface TexturalVideoProps extends React.VideoHTMLAttributes<HTMLVideoElement> {
     className?: string;
     isTransparent?: boolean;
+    /**
+     * @deprecated Use `primaryVideoUrl` or `secondaryVideoUrl` instead
+     */
     mp4?: string;
+    /**
+     * @deprecated Use `primaryVideoUrl` or `secondaryVideoUrl` instead
+     */
     webm?: string;
+    primaryVideoUrl?: string;
+    primaryVideoType?: string;
+    secondaryVideoUrl?: string;
+    secondaryVideoType?: string;
     threshold?: number;
 }
 
@@ -14,14 +24,18 @@ const TexturalVideo = ({
     isTransparent = false,
     mp4,
     webm,
+    primaryVideoUrl = mp4,
+    primaryVideoType = isTransparent ? 'video/mp4; codecs="hvc1"' : 'video/mp4',
+    secondaryVideoUrl = webm,
+    secondaryVideoType = 'video/webm',
     poster,
     threshold = 0,
     title,
     ...rest
 }: TexturalVideoProps) => {
-    if (isTransparent && !(mp4 && webm)) {
+    if (isTransparent && !(primaryVideoUrl && secondaryVideoUrl)) {
         console.warn(
-            'TexturalVideo: Please make sure you have both webm and mp4 formats for cross-browser support for transparent videos.'
+            'TexturalVideo: Please make sure you have both webm and mp4/mov formats for cross-browser support for transparent videos.'
         );
     }
 
@@ -64,6 +78,14 @@ const TexturalVideo = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isIntersecting]);
 
+    const primaryVideoSource = primaryVideoUrl && (
+        <source src={primaryVideoUrl} type={primaryVideoType} />
+    );
+
+    const secondaryVideoSource = secondaryVideoUrl && (
+        <source src={secondaryVideoUrl} type={secondaryVideoType} />
+    );
+
     return (
         <video
             ref={videoRef}
@@ -78,10 +100,8 @@ const TexturalVideo = ({
             playsInline
             {...rest}
         >
-            {mp4 && (
-                <source src={mp4} type={isTransparent ? 'video/mp4; codecs="hvc1"' : 'video/mp4'} />
-            )}
-            {webm && <source src={webm} type="video/webm" />}
+            {primaryVideoSource}
+            {secondaryVideoSource}
         </video>
     );
 };


### PR DESCRIPTION
@julianstein @AlexandraKlein

So i had this laying around for a while now (i actually thought i had deleted it but turns out i saved it in a stash). I basically rename the props `mp4` to `primaryVideoUrl` and `webm` to `secondaryVideoUrl` and add `primaryVideoType` and `secondaryVideoType` props.

I deprecated the `mp4` and `webm` props.

The changes should be backwards compatible (no breaking changes). This is both good and bad. Bad because the default `primaryVideoType` for non-transparent video is still `video/mp4` when it should be `video/webm`. We can do a major version bump later and change those defaults.

Does this fix your problem on Tillamook, Julian?