### PR TITLE
Remove "use client" directive

### DIFF
--- a/.changeset/thirty-seahorses-yell.md
+++ b/.changeset/thirty-seahorses-yell.md
@@ -1,0 +1,10 @@
+---
+"@madeinhaus/textural-video": minor
+"@madeinhaus/nextjs-theme": minor
+"@madeinhaus/disclosure": minor
+"@madeinhaus/carousel": minor
+"@madeinhaus/masonry": minor
+"@madeinhaus/slider": minor
+---
+
+Remove "use client" directive, opting for handling outside package

--- a/packages/carousel/src/index.tsx
+++ b/packages/carousel/src/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 
 import { type EasingFunction, easings, modulo, clamp, sign, last } from '../../utils/src';

--- a/packages/disclosure/src/index.tsx
+++ b/packages/disclosure/src/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import cx from 'clsx';
 import styles from './Disclosure.module.scss';

--- a/packages/masonry/src/index.tsx
+++ b/packages/masonry/src/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 // Stolen & Rewritten from https://github.com/paulcollett/react-masonry-css
 import React, { useState, useEffect } from 'react';
 import cx from 'clsx';

--- a/packages/nextjs-theme/src/index.tsx
+++ b/packages/nextjs-theme/src/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 
 const DARK = 'dark';

--- a/packages/slider/src/index.tsx
+++ b/packages/slider/src/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 
 import { useMeasure } from '../../hooks/src/useMeasure';

--- a/packages/textural-video/src/index.tsx
+++ b/packages/textural-video/src/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import { useIntersectionObserver } from '../../hooks/src/useIntersectionObserver';
 


### PR DESCRIPTION
Third-party components the solution to NextJS 13 "use client" directive is to create a wrapper for each client component that doesn't include the directive. We prematurely optimized for NextJS 13 without considering this approach.
