### PR TITLE
Carousel click events

### DIFF
--- a/.changeset/little-monkeys-walk.md
+++ b/.changeset/little-monkeys-walk.md
@@ -1,0 +1,5 @@
+---
+"@madeinhaus/carousel": patch
+---
+
+Bugfix: Allow click events to go through when disabled

--- a/packages/carousel/src/index.tsx
+++ b/packages/carousel/src/index.tsx
@@ -586,7 +586,7 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>((props, ref) => {
     };
 
     const handleClick = (event: MouseEvent) => {
-        if (dragPreventClick.current) {
+        if (dragPreventClick.current && !disabled.current) {
             // Prevent-default click events:
             // After dragging, we don't want a dangling click to go through
             event.stopPropagation();
@@ -831,6 +831,7 @@ const Carousel = React.forwardRef<CarouselRef, CarouselProps>((props, ref) => {
         container.current.classList.toggle('disabled', disabled.current);
         if (disabled.current) {
             stopAllAnimations();
+            removePointerEvents();
             items.forEach((_, index) => {
                 const node = container.current?.childNodes[index] as HTMLElement;
                 if (node) {


### PR DESCRIPTION
Click events were held hostage when carousel is disabled.
This is no longer the case with this fix.