### PR TITLE
Feature: Remove warning for adding a className to Details element

### DIFF
--- a/.changeset/fuzzy-wombats-attack.md
+++ b/.changeset/fuzzy-wombats-attack.md
@@ -1,0 +1,5 @@
+---
+"@madeinhaus/disclosure": minor
+---
+
+Remove warning when adding a className to Details element

--- a/.changeset/fuzzy-wombats-attack.md
+++ b/.changeset/fuzzy-wombats-attack.md
@@ -2,4 +2,4 @@
 "@madeinhaus/disclosure": minor
 ---
 
-Remove warning when adding a className to Details element
+Remove warning for adding a className to Details element

--- a/packages/disclosure/src/index.tsx
+++ b/packages/disclosure/src/index.tsx
@@ -121,13 +121,6 @@ const DisclosureDetails = ({
         }
     }, []);
 
-    if (className) {
-        console.warn('%c Disclosure from @madeinhaus/disclosure ↓ ', 'color: red; font-size: 14px');
-        console.warn(
-            'Use className to style the Disclosure.Details element, sparingly. To style the trigger, please apply style to Detail.Summary. To style the content within the Disclosure.Details, please apply styles to Disclosure.Content.'
-        );
-    }
-
     useEffect(() => {
         setDetailsEl(detailsRef.current);
     }, []);


### PR DESCRIPTION
There are valid reasons for a className here and I think the warning is too aggressive.